### PR TITLE
added provides section

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,5 +4,10 @@
     "description"   : "Perl 6 TOML Serializer",
     "author"        : "Mouq",
     "depends"       : ["JSON::Tiny"],
+    "provides"      : {
+        "ForeignGrammar"   : "lib/ForeignGrammar.pm",
+        "TOML"             : "lib/TOML.pm",
+        "TOML::Grammar"    : "lib/TOML/Grammar.pm"
+    },
     "source-url"    : "git://github.com/Mouq/toml-pm6.git"
 }


### PR DESCRIPTION
a provides section is needed for installing on latest rakudo/panda

```
$ panda install TOML
==> Fetching TOML
==> Building TOML
Compiling lib/ForeignGrammar.pm to mbc
Compiling lib/TOML/Grammar.pm6 to mbc
Compiling lib/TOML.pm6 to mbc
==> Testing TOML
==> Installing TOML
===WARNING!===
The distribution TOML does not seem to have a "provides" section in its META.info file,
and so the packages will not be installed in the correct location.
Please ask the author to add a "provides" section, mapping every exposed namespace to a
file location in the distribution.
See http://design.perl6.org/S22.html#provides for more information.

==> Successfully installed TOML
```

```
$ panda info TOML
TOML (version 0.3.1alpha available, 0.3.1alpha installed)
Perl 6 TOML Serializer
Depends on: JSON::Tiny
State: installed
Source-url: git://github.com/Mouq/toml-pm6.git
Author: Mouq
```

```
$ p6 t/03-config-detomled.t 
===SORRY!===
Could not find TOML in any of: /home/atweiden/p/nightscape-develop/lib, /home/atweiden/.perl6/2015.04-37-g224db5e/lib, /home/atweiden/.perl6/2015.04-37-g224db5e, /usr/share/perl6/lib, /usr/share/perl6
```
